### PR TITLE
Fix Stripe webhook signature verification with raw body

### DIFF
--- a/controllers/payment.controller.js
+++ b/controllers/payment.controller.js
@@ -75,7 +75,7 @@ module.exports.paymentWebhook = async (req, res) => {
   }
 
   try {
-    event = stripe.webhooks.constructEvent(req.body, sig, endpointSecret);
+    event = stripe.webhooks.constructEvent(req.rawBody, sig, endpointSecret);
   } catch (err) {
     console.error(`Webhook Error: ${err.message}`);
     return res.status(400).send(`Webhook Error: ${err.message}`);

--- a/index.js
+++ b/index.js
@@ -28,12 +28,16 @@ const corsOption = {
 
 app.use(cors(corsOption));
 
-app.use("/api/checkout/webhook", express.raw({ type: "application/json" }));
-
-app.use(express.json());
-
-//Body Parseer
-app.use(bodyParser.json({ limit: "10mb" }));
+app.use(
+  express.json({
+    limit: "10mb",
+    verify: (req, res, buf) => {
+      if (req.originalUrl === "/api/checkout/webhook") {
+        req.rawBody = buf;
+      }
+    },
+  })
+);
 app.use(bodyParser.urlencoded({ limit: "10mb", extended: true }));
 app.use(cookieParser());
 


### PR DESCRIPTION
## Summary
Fixed Stripe webhook signature verification by ensuring the raw request body is used for constructing webhook events, rather than the parsed JSON body.

## Key Changes
- Consolidated body parser middleware into a single `express.json()` call with a custom `verify` callback that captures the raw body buffer for webhook requests
- Removed the separate `express.raw()` middleware that was previously used for the webhook endpoint
- Updated the payment webhook handler to use `req.rawBody` instead of `req.body` when constructing Stripe webhook events

## Implementation Details
The Stripe webhook signature verification requires the raw, unparsed request body to correctly validate the HMAC signature. By using the `verify` callback in the `express.json()` middleware, we can:
- Capture the raw buffer before JSON parsing occurs
- Store it in `req.rawBody` specifically for webhook requests
- Maintain a single, cleaner middleware configuration
- Ensure all other endpoints continue to receive parsed JSON as expected

This approach is more efficient than using separate raw/json middleware and ensures the webhook signature verification works correctly.

https://claude.ai/code/session_01RCDyM6PwiecQP6ckRAtQ4y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced security of payment webhook processing by ensuring signatures are correctly validated against the original request payload, improving the authenticity verification of incoming payment events.

* **Chores**
  * Streamlined request parsing middleware configuration to reduce code duplication and improve maintainability without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->